### PR TITLE
[RFC-060] Phase 4.2: Configure workflow for RSOLV_API_KEY

### DIFF
--- a/.github/workflows/rsolv-security-scan.yml
+++ b/.github/workflows/rsolv-security-scan.yml
@@ -1,14 +1,11 @@
-# TEMPLATE: RSOLV Security Scan Workflow
+# RSOLV Security Scan Workflow
 #
-# This is a TEMPLATE workflow for distribution to target repositories.
-# Copy this file to your repository's .github/workflows/ directory.
+# This workflow runs RSOLV security scanning on this repository.
+# It supports both direct Anthropic API keys and RSOLV vended credentials.
 #
-# DEPLOYMENT INSTRUCTIONS:
-# 1. Copy this file to your repo: .github/workflows/rsolv-security-scan.yml
-# 2. Update the 'uses' reference to point to the correct RSOLV-action version
-# 3. Add required secrets to your repository settings:
-#    - ANTHROPIC_API_KEY: Your Anthropic API key for AI-powered mitigation
-# 4. Customize the workflow triggers if needed (currently: workflow_dispatch, push)
+# Required secrets:
+# - RSOLV_API_KEY: For pattern fetching and vended credentials (recommended)
+# - ANTHROPIC_API_KEY: (Optional) Direct Anthropic API key for mitigation
 #
 # This workflow will:
 # - SCAN: Detect security vulnerabilities in your repository
@@ -68,6 +65,7 @@ jobs:
             -e INPUT_MODE=scan \
             -e RSOLV_SCAN_MODE=scan \
             -e RSOLV_ENABLE_SECURITY_ANALYSIS=true \
+            -e RSOLV_API_KEY=${{ secrets.RSOLV_API_KEY }} \
             -e GITHUB_WORKSPACE=$WORKSPACE_PATH \
             -e GITHUB_OUTPUT=/tmp/github_output \
             $DOCKER_IMAGE
@@ -90,6 +88,7 @@ jobs:
             -e RSOLV_MODE=validate \
             -e INPUT_MODE=validate \
             -e RSOLV_ENABLE_AST_VALIDATION=true \
+            -e RSOLV_API_KEY=${{ secrets.RSOLV_API_KEY }} \
             -e GITHUB_WORKSPACE=$WORKSPACE_PATH \
             -e GITHUB_OUTPUT=/tmp/github_output \
             $DOCKER_IMAGE
@@ -112,6 +111,7 @@ jobs:
             -e RSOLV_MODE=mitigate \
             -e INPUT_MODE=mitigate \
             -e RSOLV_USE_GIT_BASED_EDITING=true \
+            -e RSOLV_API_KEY=${{ secrets.RSOLV_API_KEY }} \
             -e ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }} \
             -e GITHUB_WORKSPACE=$WORKSPACE_PATH \
             -e GITHUB_OUTPUT=/tmp/github_output \


### PR DESCRIPTION
## Summary
Update the workflow to support RSOLV vended credentials via `RSOLV_API_KEY`.

## Changes
- ✅ Add `RSOLV_API_KEY` to all phases (SCAN, VALIDATE, MITIGATE)
- ✅ Support both credential modes:
  - `RSOLV_API_KEY`: Vended credentials (recommended, already configured)
  - `ANTHROPIC_API_KEY`: Direct API key (optional)
- ✅ Update documentation to clarify credential options

## Testing
The workflow is ready to run using the existing `RSOLV_API_KEY` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)