### PR TITLE
[RFC-060] Phase 4.2: Add GITHUB_REPOSITORY to all workflow phases

### DIFF
--- a/.github/workflows/rsolv-security-scan.yml
+++ b/.github/workflows/rsolv-security-scan.yml
@@ -67,6 +67,7 @@ jobs:
             -e RSOLV_ENABLE_SECURITY_ANALYSIS=true \
             -e RSOLV_API_KEY=${{ secrets.RSOLV_API_KEY }} \
             -e GITHUB_WORKSPACE=$WORKSPACE_PATH \
+            -e GITHUB_REPOSITORY=${{ github.repository }} \
             -e GITHUB_OUTPUT=/tmp/github_output \
             $DOCKER_IMAGE
 
@@ -90,6 +91,7 @@ jobs:
             -e RSOLV_ENABLE_AST_VALIDATION=true \
             -e RSOLV_API_KEY=${{ secrets.RSOLV_API_KEY }} \
             -e GITHUB_WORKSPACE=$WORKSPACE_PATH \
+            -e GITHUB_REPOSITORY=${{ github.repository }} \
             -e GITHUB_OUTPUT=/tmp/github_output \
             $DOCKER_IMAGE
 
@@ -114,6 +116,7 @@ jobs:
             -e RSOLV_API_KEY=${{ secrets.RSOLV_API_KEY }} \
             -e ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }} \
             -e GITHUB_WORKSPACE=$WORKSPACE_PATH \
+            -e GITHUB_REPOSITORY=${{ github.repository }} \
             -e GITHUB_OUTPUT=/tmp/github_output \
             $DOCKER_IMAGE
 


### PR DESCRIPTION
## Summary
Fix missing `GITHUB_REPOSITORY` environment variable in all workflow phases.

## Changes
- ✅ Add `GITHUB_REPOSITORY` to SCAN phase
- ✅ Add `GITHUB_REPOSITORY` to VALIDATE phase
- ✅ Add `GITHUB_REPOSITORY` to MITIGATE phase

## Fix
Resolves: `GITHUB_REPOSITORY environment variable not set` error

## Testing
Will trigger workflow after merge to verify fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)