### PR TITLE
[RFC-060] Phase 4.2: Add GITHUB_TOKEN to all workflow phases

### DIFF
--- a/.github/workflows/rsolv-security-scan.yml
+++ b/.github/workflows/rsolv-security-scan.yml
@@ -68,6 +68,7 @@ jobs:
             -e RSOLV_API_KEY=${{ secrets.RSOLV_API_KEY }} \
             -e GITHUB_WORKSPACE=$WORKSPACE_PATH \
             -e GITHUB_REPOSITORY=${{ github.repository }} \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GITHUB_OUTPUT=/tmp/github_output \
             $DOCKER_IMAGE
 
@@ -92,6 +93,7 @@ jobs:
             -e RSOLV_API_KEY=${{ secrets.RSOLV_API_KEY }} \
             -e GITHUB_WORKSPACE=$WORKSPACE_PATH \
             -e GITHUB_REPOSITORY=${{ github.repository }} \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GITHUB_OUTPUT=/tmp/github_output \
             $DOCKER_IMAGE
 
@@ -117,6 +119,7 @@ jobs:
             -e ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }} \
             -e GITHUB_WORKSPACE=$WORKSPACE_PATH \
             -e GITHUB_REPOSITORY=${{ github.repository }} \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GITHUB_OUTPUT=/tmp/github_output \
             $DOCKER_IMAGE
 


### PR DESCRIPTION
## Summary
Add `GITHUB_TOKEN` environment variable to enable GitHub API access.

## Changes
- ✅ Add `GITHUB_TOKEN` to all three phases

## Fix
Resolves: `No GitHub token found. Please set GITHUB_TOKEN environment variable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)