### PR TITLE
Fix workflow: Set max_issues=1 to avoid storePhaseResults error

### DIFF
--- a/.github/workflows/rsolv-three-phase-demo.yml
+++ b/.github/workflows/rsolv-three-phase-demo.yml
@@ -32,7 +32,7 @@ jobs:
           rsolvApiKey: ${{ secrets.RSOLV_API_KEY }}
           api_url: https://rsolv-staging.com
           mode: 'scan'
-          max_issues: 2  # Limit to 2 issues for demo purposes
+          max_issues: 1  # Process one issue at a time to avoid storePhaseResults error purposes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEBUG: ${{ inputs.debug && 'rsolv:*' || '' }}
@@ -61,7 +61,7 @@ jobs:
           api_url: https://rsolv-staging.com
           mode: 'validate'
           issue_label: 'rsolv:detected'
-          max_issues: 2  # Validate only 2 issues to keep runtime reasonable
+          max_issues: 1  # Validate only 2 issues to keep runtime reasonable
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEBUG: ${{ inputs.debug && 'rsolv:*' || '' }}
@@ -97,7 +97,7 @@ jobs:
           api_url: https://rsolv-staging.com
           mode: 'mitigate'
           issue_label: 'rsolv:validated'
-          max_issues: 2  # Limit to 2 issues for demo
+          max_issues: 1  # Process one issue at a time to avoid storePhaseResults error
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEBUG: ${{ inputs.debug && 'rsolv:*' || '' }}


### PR DESCRIPTION
## Problem

The three-phase workflow was failing in MITIGATE phase with error:
```
Error: Issue number is required for mitigate phase
```

## Root Cause

When `max_issues > 1`, the action processes multiple issues but the `storePhaseResults` function requires a single `issue_number` field. This creates an ambiguity when storing results for multiple issues.

## Solution

Set `max_issues: 1` in all three phases (SCAN, VALIDATE, MITIGATE) to ensure:
- Clear single issue context for all operations
- Unambiguous `issue_number` for platform API calls
- Successful phase result storage

## Changes

- SCAN: `max_issues: 2` → `max_issues: 1`
- VALIDATE: `max_issues: 2` → `max_issues: 1`  
- MITIGATE: `max_issues: 2` → `max_issues: 1`

## Testing

- RailsGoat repository already uses this configuration successfully
- All three phases completed end-to-end with this setting
- Platform API calls work correctly with single issue context

## Related

- RFC-067 Week 5-6 testing
- Issue identified during staging environment testing
- Part of GitHub Marketplace launch preparation