### PR TITLE
chore: Update rsolv-action to @v3 across all workflows

### DIFF
--- a/.github/workflows/fresh-full-test.yml
+++ b/.github/workflows/fresh-full-test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run RSOLV SCAN Phase
-        uses: RSOLV-dev/RSOLV-action@v3.8.85
+        uses: RSOLV-dev/RSOLV-action@v3
         id: scan
         with:
           mode: SCAN
@@ -36,7 +36,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run RSOLV VALIDATE Phase
-        uses: RSOLV-dev/RSOLV-action@v3.8.85
+        uses: RSOLV-dev/RSOLV-action@v3
         id: validate
         with:
           mode: VALIDATE
@@ -64,7 +64,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run RSOLV MITIGATE Phase
-        uses: RSOLV-dev/RSOLV-action@v3.8.85
+        uses: RSOLV-dev/RSOLV-action@v3
         id: mitigate
         with:
           mode: MITIGATE

--- a/.github/workflows/fresh-test-with-prs.yml
+++ b/.github/workflows/fresh-test-with-prs.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Phase 1 - SCAN for vulnerabilities (creates issues)
         id: scan
-        uses: RSOLV-dev/RSOLV-action@v3.7.45
+        uses: RSOLV-dev/RSOLV-action@v3
         with:
           mode: scan
           rsolvApiKey: ${{ secrets.RSOLV_API_KEY }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Phase 2 - VALIDATE vulnerabilities (creates test branches)
         id: validate
-        uses: RSOLV-dev/RSOLV-action@v3.7.45
+        uses: RSOLV-dev/RSOLV-action@v3
         with:
           mode: validate
           rsolvApiKey: ${{ secrets.RSOLV_API_KEY }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Phase 3 - MITIGATE vulnerabilities (creates PRs)
         id: mitigate
-        uses: RSOLV-dev/RSOLV-action@v3.7.45
+        uses: RSOLV-dev/RSOLV-action@v3
         with:
           mode: mitigate
           rsolvApiKey: ${{ secrets.RSOLV_API_KEY }}

--- a/.github/workflows/rfc060-production-validation.yml
+++ b/.github/workflows/rfc060-production-validation.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run RSOLV SCAN Phase (Production)
-        uses: RSOLV-dev/RSOLV-action@v3.8.31
+        uses: RSOLV-dev/RSOLV-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -34,7 +34,7 @@ jobs:
           max_issues: ${{ github.event.inputs.max_issues || '2' }}
 
       - name: Run RSOLV VALIDATE Phase (Production)
-        uses: RSOLV-dev/RSOLV-action@v3.8.31
+        uses: RSOLV-dev/RSOLV-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -45,7 +45,7 @@ jobs:
           max_issues: ${{ github.event.inputs.max_issues || '2' }}
 
       - name: Run RSOLV MITIGATE Phase (Production)
-        uses: RSOLV-dev/RSOLV-action@v3.8.31
+        uses: RSOLV-dev/RSOLV-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test-pr-creation-mitigate-only.yml
+++ b/.github/workflows/test-pr-creation-mitigate-only.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: MITIGATE
-        uses: RSOLV-dev/RSOLV-action@v3.7.59
+        uses: RSOLV-dev/RSOLV-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test-pr-creation.yml
+++ b/.github/workflows/test-pr-creation.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: VALIDATE
-        uses: RSOLV-dev/RSOLV-action@v3.7.59
+        uses: RSOLV-dev/RSOLV-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -20,7 +20,7 @@ jobs:
           api_url: https://rsolv.dev
           issue_number: '1074'
       - name: MITIGATE
-        uses: RSOLV-dev/RSOLV-action@v3.7.59
+        uses: RSOLV-dev/RSOLV-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- Updates 5 workflow files that were pinned to stale rsolv-action versions (v3.7.45, v3.7.59, v3.8.31, v3.8.85) to use the rolling `@v3` tag
- The `@v3` tag currently points to v3.9.10 which includes platform-first test classification (RFC-103 Phase 3.5), RFC-101 project shape detection, RFC-104 CWE registry, and many other improvements
- `rfc060-staging-validation.yml` intentionally left on `@main` and `test-sdk-adapter-periodic.yml` was already on `@v3`

## Files changed
| Workflow | Old version | New version |
|----------|------------|-------------|
| `fresh-full-test.yml` | v3.8.85 | v3 |
| `fresh-test-with-prs.yml` | v3.7.45 | v3 |
| `rfc060-production-validation.yml` | v3.8.31 | v3 |
| `test-pr-creation.yml` | v3.7.59 | v3 |
| `test-pr-creation-mitigate-only.yml` | v3.7.59 | v3 |

## Test plan
- [ ] Run `fresh-full-test.yml` workflow dispatch to verify SCAN/VALIDATE/MITIGATE all work with latest action
- [ ] Confirm test classification results are behavioral (not static) with platform-first classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)